### PR TITLE
0.3.0 Dime updates

### DIFF
--- a/dime/CHANGELOG.md
+++ b/dime/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0-rc - Dime static change
+
+- refactored to use static methods as `dime*` not `Dime.` static class
+- `Dime.` still available via deprecated API notation
+- changed name from `inject` to `get` to better match name to function of the method
+- `inject` still available via deprecated API notation
+- Code styles updates based on effective-dart lint rules.
+
 ## 0.2.0 - Bug fix
 
 - added same module getion visible to next getions

--- a/dime/CHANGELOG.md
+++ b/dime/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.0 - Bug fix
 
-- added same module injection visible to next injections
+- added same module getion visible to next getions
 
 ## 0.1.1 - Scopes updates
 
@@ -9,9 +9,9 @@
 
 ## 0.1.0 - initial release
 
-- Dependency Injection with global scope.
-- Inject with modules and sub-scopes's modules.
+- Dependency getion with global scope.
+- get with modules and sub-scopes's modules.
 - Support for modules and scopes.
-- Creator types, on demand injection
+- Creator types, on demand getion
 - Ability to add singletons and singleton of same type per tag.
 - Closable types will be properly disposed when closing scopes

--- a/dime/CHANGELOG.md
+++ b/dime/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.3.0-rc - Dime static change
+## 0.3.0 - Dime static change
 
 - refactored to use static methods as `dime*` not `Dime.` static class
 - `Dime.` still available via deprecated API notation
 - changed name from `inject` to `get` to better match name to function of the method
 - `inject` still available via deprecated API notation
 - Code styles updates based on effective-dart lint rules.
+- Adding global scope property - to be used with Dime Flutter package (in development)
 
 ## 0.2.0 - Bug fix
 

--- a/dime/README.md
+++ b/dime/README.md
@@ -38,7 +38,7 @@ void main() {
 ```yaml
  depedency: 
    ...
-   dime: ^0.3.0-rc
+   dime: ^0.3.0
    ...
 ```
 

--- a/dime/README.md
+++ b/dime/README.md
@@ -1,6 +1,8 @@
-Dime is Dart based Dependency getion framework.
+Dime is Dart Dependency injection framework.
 
-Dime allows to create modules and get based on interfaces, provides way to specify factory methods and tag based same type instances.
+Dime allows to create modules that define injection types and their InjectFactory implementations.
+It can easily base on interfaces which allows to pick different implementations. 
+Supports for tag tag based same type instances.
 Support for multiple modules and scopes with `Closable` interface to cleanup resources.
 
 Get it from pub page: [Pub dime page](https://pub.dartlang.org/packages/dime)

--- a/dime/README.md
+++ b/dime/README.md
@@ -17,9 +17,11 @@ import 'package:dime/dime.dart';
 
 void main() {
   /// Service Module does include details how to create the objects.   
-  Dime.installModule(ServiceModule());
+  dimeInstall(ServiceModule());
      
-  MyTitleService titleService = Dime.get();
+  MyTitleService titleService = dimeGet();
+  // or 
+  var titleService = dimeGet<MyTitleService>();
   print(titleService.text());
   
 }
@@ -85,7 +87,7 @@ get singleton value by implementing interface:
 
 This is creator - which will create an object at time of getion.
 ```dart
-typedef T Creator<T>(String tag);
+typedef Creator<T> = T Function(String tag);
 ```
 
 The Creator provides optional `String tag` that may be used to create the tagged instance.
@@ -124,10 +126,8 @@ When a scope closes all modules in that scope will also close (clean up) by call
 #### Add Module to Global Dime scope.
 
 ```dart
-  Dime.installModule(ServiceModule());
+  dimeInstall(ServiceModule());
 ```
-
-
 
 
 ## Features and bugs

--- a/dime/README.md
+++ b/dime/README.md
@@ -1,6 +1,6 @@
-Dime is Dart based Dependency Injection framework.
+Dime is Dart based Dependency getion framework.
 
-Dime allows to create modules and inject based on interfaces, provides way to specify factory methods and tag based same type instances.
+Dime allows to create modules and get based on interfaces, provides way to specify factory methods and tag based same type instances.
 Support for multiple modules and scopes with `Closable` interface to cleanup resources.
 
 Get it from pub page: [Pub dime page](https://pub.dartlang.org/packages/dime)
@@ -19,7 +19,7 @@ void main() {
   /// Service Module does include details how to create the objects.   
   Dime.installModule(ServiceModule());
      
-  MyTitleService titleService = Dime.inject();
+  MyTitleService titleService = Dime.get();
   print(titleService.text());
   
 }
@@ -43,47 +43,47 @@ void main() {
 Create a module and how it creates its dependencies:
 
 ```dart
-class MyModule  extends BaseAppInjectorModule {
+class MyModule  extends BaseAppgetorModule {
     @override
-    void updateInjections() {
-        /// define injection factories - below for examples      
+    void updategetions() {
+        /// define getion factories - below for examples      
     }
 }
 
 ```
 
-Below are examples that can be used inside `updateInjections` method.
+Below are examples that can be used inside `updategetions` method.
 
 #### Singleton per type
 
-Inject single value by its class type:
+get single value by its class type:
 
 ```dart
   addSingle(MyTitleService());
 ```
 
-Inject singleton value by implementing interface:
+get singleton value by implementing interface:
 ```dart
   addSingle<TitleService>(MyTitleService());
 ```
 
 #### Singleton per type with tag
 
-Inject single value by its class type:
+get single value by its class type:
 
 ```dart
   addSingle(MyTitleService(), tag: "home-title");
   addSingle(MyTitleService(), tag: "details-title");
 ```
 
-Inject singleton value by implementing interface:
+get singleton value by implementing interface:
 ```dart
   addSingle<TitleService>(MyTitleService(), tag: "home-title");
 ```
 
-#### Creator on-demand injection, it uses type of Creator
+#### Creator on-demand getion, it uses type of Creator
 
-This is creator - which will create an object at time of injection.
+This is creator - which will create an object at time of getion.
 ```dart
 typedef T Creator<T>(String tag);
 ```
@@ -94,7 +94,7 @@ The Creator provides optional `String tag` that may be used to create the tagged
 addCreator<TextService>((tag) =>
         MyTitleService(title: "Test title: $tag: now: ${DateTime.now()}"));
 ```
-#### Creator on-demand injection with singleton storage - delayed singleton.
+#### Creator on-demand getion with singleton storage - delayed singleton.
 
 Similar to above example with `addCreator`, however created instance will be cached per tag.
 
@@ -104,7 +104,7 @@ addSingleByCreator((tag)=>MyDescriptionService());
 
 #### Create your own factory.
 
-You can always create your own factory by extending `InjectFactory<T>` and add those to the module.
+You can always create your own factory by extending `getFactory<T>` and add those to the module.
 
 ```dart
  addFactory(MyTooltipService, MyCustomFactory());
@@ -112,9 +112,9 @@ You can always create your own factory by extending `InjectFactory<T>` and add t
 
 __Note:__
 There are some other Factories already provided to be used - like:
-- `InjectTagFactory` for create method with a Tag
-- `TaggedSingletonInjectFactory` - for tagged singletons with `Closeable` interface
-- `SingleInjectFactory` - single inject factory with `Closable` interface
+- `getTagFactory` for create method with a Tag
+- `TaggedSingletongetFactory` - for tagged singletons with `Closeable` interface
+- `SinglegetFactory` - single get factory with `Closable` interface
 
 ### Add modules to the scope (global too)
 

--- a/dime/README.md
+++ b/dime/README.md
@@ -34,7 +34,7 @@ void main() {
 ```yaml
  depedency: 
    ...
-   dime: ^0.2.0
+   dime: ^0.3.0
    ...
 ```
 
@@ -45,8 +45,8 @@ Create a module and how it creates its dependencies:
 ```dart
 class MyModule  extends BaseAppgetorModule {
     @override
-    void updategetions() {
-        /// define getion factories - below for examples      
+    void updateInjections() {
+        /// define injection factories - below for examples      
     }
 }
 

--- a/dime/README.md
+++ b/dime/README.md
@@ -36,7 +36,7 @@ void main() {
 ```yaml
  depedency: 
    ...
-   dime: ^0.3.0
+   dime: ^0.3.0-rc
    ...
 ```
 

--- a/dime/example/dime_example.dart
+++ b/dime/example/dime_example.dart
@@ -7,39 +7,38 @@ import '../test/common.dart';
 void main() {
   Fimber.plantTree(DebugTree.elapsed());
   Fimber.i("Started app");
-  Dime.installModule(ServiceModule());
+  dimeInstall(ServiceModule());
   Fimber.i("Installed module");
-  var scope = DimeScope("test");
+  var scope = dimeOpenScope("test");
   scope.installModule(ScopeModule());
-  Dime.addScope(scope);
 
   // ignore: omit_local_variable_types
-  MyTitleService titleService = Dime.get();
+  MyTitleService titleService = dimeGet();
   print(titleService.text());
 
   // ignore: omit_local_variable_types
-  MyTitleService titleService2 = Dime.get(tag: "Test tag");
+  MyTitleService titleService2 = dimeGetWithTag("Test tag");
   print(titleService2.text());
 
-  var creatorService = Dime.get<TextService>();
+  var creatorService = dimeGet<TextService>();
   print(creatorService.text());
 
-  creatorService = Dime.get<TextService>(tag: "TEST TAG A");
+  creatorService = dimeGet<TextService>(tag: "TEST TAG A");
   print(creatorService.text());
 
-  var scopeTitle = Dime.get<MyTitleService>();
+  var scopeTitle = dimeGet<MyTitleService>();
   print(scopeTitle.text());
 
-  scopeTitle = scope.get<MyTitleService>();
+  scopeTitle = dimeGet<MyTitleService>();
   print(scopeTitle.text());
 
-  var tooltip = Dime.get<MyTooltipService>();
+  var tooltip = dimeGet<MyTooltipService>();
   print(tooltip.text());
 
   var scopeDescription = scope.get<MyDescriptionService>();
   print(scopeDescription.text());
 
-  Dime.closeScope(scope: scope);
+  dimeCloseScope(scope: scope);
 
   scopeDescription = scope.get<MyDescriptionService>();
   print(scopeDescription.text());

--- a/dime/example/dime_example.dart
+++ b/dime/example/dime_example.dart
@@ -14,34 +14,34 @@ void main() {
   Dime.addScope(scope);
 
   // ignore: omit_local_variable_types
-  MyTitleService titleService = Dime.inject();
+  MyTitleService titleService = Dime.get();
   print(titleService.text());
 
   // ignore: omit_local_variable_types
-  MyTitleService titleService2 = Dime.inject(tag: "Test tag");
+  MyTitleService titleService2 = Dime.get(tag: "Test tag");
   print(titleService2.text());
 
-  var creatorService = Dime.inject<TextService>();
+  var creatorService = Dime.get<TextService>();
   print(creatorService.text());
 
-  creatorService = Dime.inject<TextService>(tag: "TEST TAG A");
+  creatorService = Dime.get<TextService>(tag: "TEST TAG A");
   print(creatorService.text());
 
-  var scopeTitle = Dime.inject<MyTitleService>();
+  var scopeTitle = Dime.get<MyTitleService>();
   print(scopeTitle.text());
 
-  scopeTitle = scope.inject<MyTitleService>();
+  scopeTitle = scope.get<MyTitleService>();
   print(scopeTitle.text());
 
-  var tooltip = Dime.inject<MyTooltipService>();
+  var tooltip = Dime.get<MyTooltipService>();
   print(tooltip.text());
 
-  var scopeDescription = scope.inject<MyDescriptionService>();
+  var scopeDescription = scope.get<MyDescriptionService>();
   print(scopeDescription.text());
 
   Dime.closeScope(scope: scope);
 
-  scopeDescription = scope.inject<MyDescriptionService>();
+  scopeDescription = scope.get<MyDescriptionService>();
   print(scopeDescription.text());
 }
 

--- a/dime/lib/dime.dart
+++ b/dime/lib/dime.dart
@@ -5,4 +5,5 @@ library dime;
 
 export 'src/common.dart';
 export 'src/dime_base.dart';
+export 'src/dime_static.dart';
 export 'src/factories.dart';

--- a/dime/lib/src/dime_base.dart
+++ b/dime/lib/src/dime_base.dart
@@ -44,8 +44,8 @@ class DimeScope extends Closable {
     module.updateInjections();
     if (override) {
       // override this scope values
-      module.injectMap.keys.forEach((newModuleType) {
-        _modules.forEach((currentModule) {
+      for (var newModuleType in module.injectMap.keys) {
+        for (var currentModule in _modules) {
           if (currentModule != module &&
               currentModule.injectMap.containsKey(newModuleType)) {
             Fimber.i(
@@ -55,12 +55,12 @@ class DimeScope extends Closable {
             Closable.closeWith(currentModule.injectMap[newModuleType]);
             currentModule.injectMap.remove(newModuleType);
           }
-        });
-      });
+        }
+      }
     } else {
       // detect duplicate for the type
-      module.injectMap.keys.forEach((newModuleType) {
-        _modules.forEach((currentModule) {
+      for (var newModuleType in module.injectMap.keys) {
+        for (var currentModule in _modules) {
           if (currentModule != module &&
               currentModule.injectMap.containsKey(newModuleType)) {
             // todo Do we need resolve duplicates per tag?
@@ -68,8 +68,8 @@ class DimeScope extends Closable {
             throw DimeException.message("Found duplicate type: $newModuleType "
                 "inside current scope modules.");
           }
-        });
-      });
+        }
+      }
     }
   }
 

--- a/dime/lib/src/dime_base.dart
+++ b/dime/lib/src/dime_base.dart
@@ -1,10 +1,13 @@
+import 'dart:core' as prefix0;
+import 'dart:core';
+
 import 'package:dime/src/common.dart';
 import 'package:dime/src/factories.dart';
 import 'package:fimber/fimber.dart';
 
 // ignore: avoid_classes_with_only_static_members
 /// Main Dime Dependency Injection Framework utility class
-/// After installing a module we can access module's instances via [inject].
+/// After installing a module we can access module's instances via [get].
 ///
 class Dime {
   /// Global scope
@@ -12,20 +15,35 @@ class Dime {
 
   /// Fetches a value and returns it base on [T] type
   /// and instance identifier [tag].
+  static T getWithTag<T>(String tag) {
+    return get(tag: tag);
+  }
+
+  /// Fetches a value and returns it base on [T] type
+  /// and instance identifier [tag].
+  /// [Deprecated] - use [getWithTag] method.
+  @deprecated
   static T injectWithTag<T>(String tag) {
-    return inject(tag: tag);
+    return getWithTag(tag);
   }
 
   /// Fetches a value and returns based on [T] type
   /// and optional instance identifier [tag].
-  ///
-  static T inject<T>({String tag}) {
-    var instance = _rootScope._inject<T>(tag: tag);
+  static T get<T>({String tag}) {
+    var instance = _rootScope._get<T>(tag: tag);
     if (instance == null) {
       throw DimeException.factoryNotFound(type: T);
     } else {
       return instance;
     }
+  }
+
+  /// Fetches a value and returns based on [T] type
+  /// and optional instance identifier [tag].
+  /// [Deprecated] - use [get] method.
+  @deprecated
+  static T inject<T>({String tag}) {
+    return get(tag: tag);
   }
 
   /// Adds child scope to this scope.
@@ -183,34 +201,43 @@ class DimeScope extends Closable {
     _wasClosed = true;
   }
 
-  T _inject<T>({String tag}) {
+  T _get<T>({String tag}) {
     if (_wasClosed) {
       throw DimeException.scopeClosed(scope: this);
     }
     T value;
     // check modules
     for (var module in _modules) {
-      value = module.inject<T>(tag: tag);
+      value = module.get<T>(tag: tag);
       if (value != null) return value;
     }
     if (value == null) {
-      return _parent?.inject<T>(tag: tag);
+      return _parent?.get<T>(tag: tag);
     }
     return null;
   }
 
   /// Fetches a value from a module or child scopes to satisfy [T]
   /// and optional [tag]
-  T inject<T>({String tag}) {
+
+  T get<T>({String tag}) {
     if (_wasClosed) {
       throw DimeException.scopeClosed(scope: this);
     }
-    var instance = _inject<T>(tag: tag);
+    var instance = _get<T>(tag: tag);
     if (instance == null) {
       throw DimeException.factoryNotFound(type: T);
     } else {
       return instance;
     }
+  }
+
+  /// Fetches a value from a module or child scopes to satisfy [T]
+  /// and optional [tag]
+  /// [Deprecated] use [get] method
+  @deprecated
+  T inject<T>({String tag}) {
+    return get(tag: tag);
   }
 
   /// Opens new scope by [name] and adds as child to this scope

--- a/dime/lib/src/dime_static.dart
+++ b/dime/lib/src/dime_static.dart
@@ -1,3 +1,6 @@
+import 'dart:core' as prefix0;
+import 'dart:core';
+
 import 'package:dime/src/common.dart';
 import 'package:dime/src/dime_base.dart';
 import 'package:dime/src/factories.dart';
@@ -5,15 +8,13 @@ import 'package:dime/src/factories.dart';
 // ignore: avoid_classes_with_only_static_members
 /// Main Dime Dependency Injection Framework utility class
 /// After installing a module we can access module's instances via [get].
-///
+/// [Deprecated] due to static method access do not need class.
+@deprecated
 class Dime {
-  /// Global scope
-  static final DimeScope _rootScope = DimeScope("root");
-
   /// Fetches a value and returns it base on [T] type
   /// and instance identifier [tag].
   static T getWithTag<T>(String tag) {
-    return get(tag: tag);
+    return dimeGetWithTag(tag);
   }
 
   /// Fetches a value and returns it base on [T] type
@@ -21,18 +22,13 @@ class Dime {
   /// [Deprecated] - use [getWithTag] method.
   @deprecated
   static T injectWithTag<T>(String tag) {
-    return getWithTag(tag);
+    return dimeGetWithTag(tag);
   }
 
   /// Fetches a value and returns based on [T] type
   /// and optional instance identifier [tag].
   static T get<T>({String tag}) {
-    var instance = _rootScope.get<T>(tag: tag);
-    if (instance == null) {
-      throw DimeException.factoryNotFound(type: T);
-    } else {
-      return instance;
-    }
+    return dimeGet(tag: tag);
   }
 
   /// Fetches a value and returns based on [T] type
@@ -40,46 +36,40 @@ class Dime {
   /// [Deprecated] - use [get] method.
   @deprecated
   static T inject<T>({String tag}) {
-    return get(tag: tag);
+    return dimeGet(tag: tag);
   }
 
   /// Adds child scope to this scope.
   static void addScope(DimeScope scope) {
-    _rootScope.addScope(scope);
+    dimeAddScope(scope);
   }
 
   /// Opens a scope by name,
   /// will return the created scope.
   static DimeScope openScope(String name) {
-    var scope = DimeScope(name);
-    addScope(scope);
-    return scope;
+    return dimeOpenScope(name);
   }
 
   /// Closes scope by name or scope
   static void closeScope({String name, DimeScope scope}) {
-    if (name != null) {
-      _rootScope.closeScope(name: name);
-    } else if (scope != null) {
-      _rootScope.closeScope(scope: scope);
-    }
+    dimeCloseScope(name: name, scope: scope);
   }
 
   /// Clears all modules
   static void clearAll() {
-    _rootScope.close();
+    dimeReset();
   }
 
   /// Uninstalls module with closing any [Closable] instances in the module
   static void uninstallModule(BaseDimeModule module) {
-    _rootScope.uninstallModule(module);
+    dimeUninstall(module);
   }
 
   /// Installs [module] in the Dime root scope.
   /// [override] if set True it will override any currently inject
   /// factory for the type/tag
   static void installModule(BaseDimeModule module, {bool override = false}) {
-    _rootScope.installModule(module, override: override);
+    dimeInstall(module, override: override);
   }
 }
 

--- a/dime/lib/src/dime_static.dart
+++ b/dime/lib/src/dime_static.dart
@@ -75,6 +75,9 @@ class Dime {
 
 final DimeScope _rootScope = DimeScope("root");
 
+/// Returns Dime root scope - top level scope for the Isolate.
+DimeScope get dimeRootScope => _rootScope;
+
 /// Fetches a value and returns it base on [T] type
 /// and instance identifier [tag].
 T dimeGetWithTag<T>(String tag) {

--- a/dime/lib/src/dime_static.dart
+++ b/dime/lib/src/dime_static.dart
@@ -1,0 +1,145 @@
+import 'package:dime/src/common.dart';
+import 'package:dime/src/dime_base.dart';
+import 'package:dime/src/factories.dart';
+
+// ignore: avoid_classes_with_only_static_members
+/// Main Dime Dependency Injection Framework utility class
+/// After installing a module we can access module's instances via [get].
+///
+class Dime {
+  /// Global scope
+  static final DimeScope _rootScope = DimeScope("root");
+
+  /// Fetches a value and returns it base on [T] type
+  /// and instance identifier [tag].
+  static T getWithTag<T>(String tag) {
+    return get(tag: tag);
+  }
+
+  /// Fetches a value and returns it base on [T] type
+  /// and instance identifier [tag].
+  /// [Deprecated] - use [getWithTag] method.
+  @deprecated
+  static T injectWithTag<T>(String tag) {
+    return getWithTag(tag);
+  }
+
+  /// Fetches a value and returns based on [T] type
+  /// and optional instance identifier [tag].
+  static T get<T>({String tag}) {
+    var instance = _rootScope.get<T>(tag: tag);
+    if (instance == null) {
+      throw DimeException.factoryNotFound(type: T);
+    } else {
+      return instance;
+    }
+  }
+
+  /// Fetches a value and returns based on [T] type
+  /// and optional instance identifier [tag].
+  /// [Deprecated] - use [get] method.
+  @deprecated
+  static T inject<T>({String tag}) {
+    return get(tag: tag);
+  }
+
+  /// Adds child scope to this scope.
+  static void addScope(DimeScope scope) {
+    _rootScope.addScope(scope);
+  }
+
+  /// Opens a scope by name,
+  /// will return the created scope.
+  static DimeScope openScope(String name) {
+    var scope = DimeScope(name);
+    addScope(scope);
+    return scope;
+  }
+
+  /// Closes scope by name or scope
+  static void closeScope({String name, DimeScope scope}) {
+    if (name != null) {
+      _rootScope.closeScope(name: name);
+    } else if (scope != null) {
+      _rootScope.closeScope(scope: scope);
+    }
+  }
+
+  /// Clears all modules
+  static void clearAll() {
+    _rootScope.close();
+  }
+
+  /// Uninstalls module with closing any [Closable] instances in the module
+  static void uninstallModule(BaseDimeModule module) {
+    _rootScope.uninstallModule(module);
+  }
+
+  /// Installs [module] in the Dime root scope.
+  /// [override] if set True it will override any currently inject
+  /// factory for the type/tag
+  static void installModule(BaseDimeModule module, {bool override = false}) {
+    _rootScope.installModule(module, override: override);
+  }
+}
+
+final DimeScope _rootScope = DimeScope("root");
+
+/// Fetches a value and returns it base on [T] type
+/// and instance identifier [tag].
+T dimeGetWithTag<T>(String tag) {
+  return dimeGet(tag: tag);
+}
+
+/// Fetches a value and returns based on [T] type
+/// and optional instance identifier [tag].
+T dimeGet<T>({String tag}) {
+  var instance = _rootScope.get<T>(tag: tag);
+  if (instance == null) {
+    throw DimeException.factoryNotFound(type: T);
+  } else {
+    return instance;
+  }
+}
+
+/// Adds child scope to this scope.
+void dimeAddScope(DimeScope scope) {
+  _rootScope.addScope(scope);
+}
+
+/// Opens a scope by name,
+/// will return the created scope.
+DimeScope dimeOpenScope(String name) {
+  var scope = DimeScope(name);
+  dimeAddScope(scope);
+  return scope;
+}
+
+/// Closes scope by name or scope
+void dimeCloseScope({String name, DimeScope scope}) {
+  if (name != null) {
+    _rootScope.closeScope(name: name);
+  } else if (scope != null) {
+    _rootScope.closeScope(scope: scope);
+  }
+}
+
+/// Closes Dime global scope and its child scopes.
+void dimeClose() {
+  _rootScope.close();
+}
+
+/// Resets global scope, clears all child scopes and modules.
+void dimeReset() {
+  _rootScope.reset();
+}
+
+/// Installs [module] to the global scope of Dime.
+void dimeInstall(BaseDimeModule module, {bool override = false}) {
+  _rootScope.installModule(module, override: override);
+}
+
+/// Uninstalls [module] to global scope of Dime.
+void dimeUninstall(BaseDimeModule module) {
+  _rootScope.uninstallModule(module);
+}

--- a/dime/lib/src/factories.dart
+++ b/dime/lib/src/factories.dart
@@ -70,8 +70,8 @@ abstract class BaseDimeModule with Closable {
     }
   }
 
-  /// Injects the created value from the module
-  T inject<T>({String tag}) {
+  /// Gets the created value from the module
+  T get<T>({String tag}) {
     var name = T.toString();
     var injectFactory = injectMap[T];
 
@@ -94,7 +94,15 @@ abstract class BaseDimeModule with Closable {
       return null;
     }
   }
+  /// Injects the created value from the module
+  /// [Deprecated] - use [get]
+  @deprecated
+  T inject<T>({String tag}) {
+    return get(tag: tag);
+  }
 
+
+  /// Closes the module and all its [InjectFactory].
   @override
   void close() {
     _injectMap.forEach((type, factory) {

--- a/dime/pubspec.yaml
+++ b/dime/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dime
 description: Dime is Dependency getion for Dart, allows to define modules with signle/creator inejction factories, allows String tagging and simple Scope tree.
-version: 0.2.0
+version: 0.3.0-rc
 homepage: https://github.com/magillus/dart_dime
 author: Mateusz Perlak <mati.akip@gmail.com>
 

--- a/dime/pubspec.yaml
+++ b/dime/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dime
 description: Dime is Dependency getion for Dart, allows to define modules with signle/creator inejction factories, allows String tagging and simple Scope tree.
-version: 0.3.0-rc
+version: 0.3.0
 homepage: https://github.com/magillus/dart_dime
 author: Mateusz Perlak <mati.akip@gmail.com>
 

--- a/dime/pubspec.yaml
+++ b/dime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dime
-description: Dime is Dependency Injection for Dart, allows to define modules with signle/creator inejction factories, allows String tagging and simple Scope tree.
+description: Dime is Dependency getion for Dart, allows to define modules with signle/creator inejction factories, allows String tagging and simple Scope tree.
 version: 0.2.0
 homepage: https://github.com/magillus/dart_dime
 author: Mateusz Perlak <mati.akip@gmail.com>

--- a/dime/test/common.dart
+++ b/dime/test/common.dart
@@ -75,7 +75,7 @@ abstract class TextService {
 }
 
 class DetailsService {
-  TextService title = Dime.get<MyTitleService>();
-  TextService description = Dime.get<MyDescriptionService>();
-  TextService tooltip = Dime.get<MyTooltipService>();
+  TextService title = dimeGet<MyTitleService>();
+  TextService description = dimeGet<MyDescriptionService>();
+  TextService tooltip = dimeGet<MyTooltipService>();
 }

--- a/dime/test/common.dart
+++ b/dime/test/common.dart
@@ -75,7 +75,7 @@ abstract class TextService {
 }
 
 class DetailsService {
-  TextService title = Dime.inject<MyTitleService>();
-  TextService description = Dime.inject<MyDescriptionService>();
-  TextService tooltip = Dime.inject<MyTooltipService>();
+  TextService title = Dime.get<MyTitleService>();
+  TextService description = Dime.get<MyDescriptionService>();
+  TextService tooltip = Dime.get<MyTooltipService>();
 }

--- a/dime/test/dime_test.dart
+++ b/dime/test/dime_test.dart
@@ -9,19 +9,19 @@ void main() {
   Fimber.plantTree(DebugTree());
   group('Dime inject', () {
     setUp(() {
-      Dime.clearAll();
-      Dime.installModule(SinglesModule());
+      dimeReset();
+      dimeInstall(SinglesModule());
     });
 
     test('inject on Interface Test', () {
-      var textService = Dime.get<TextService>();
+      var textService = dimeGet<TextService>();
       assert(textService != null);
       assert(textService is MyDescriptionService);
       expect(textService.text(), "Some description for tests.");
     });
 
     test('inject on class MyTitleService', () {
-      var textService = Dime.get<MyTitleService>();
+      var textService = dimeGet<MyTitleService>();
       assert(textService != null);
       assert(textService is MyTitleService);
       expect(textService.text(), "My text title");
@@ -29,7 +29,7 @@ void main() {
 
     test('inject on class MyDescriptionService', () {
       try {
-        Dime.get<MyDescriptionService>();
+        dimeGet<MyDescriptionService>();
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         assert(e is DimeException);
@@ -39,7 +39,7 @@ void main() {
     });
 
     test('inject on class MyTooltipService', () {
-      var textService = Dime.get<MyTooltipService>();
+      var textService = dimeGet<MyTooltipService>();
       assert(textService != null);
       assert(textService is MyTooltipService);
       expect(textService.text(), "test tooltip");
@@ -47,7 +47,7 @@ void main() {
 
     test('add new module', () {
       try {
-        Dime.installModule(SinglesModuleCopy());
+        dimeInstall(SinglesModuleCopy());
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         expect(e.runtimeType, DimeException);
@@ -57,20 +57,20 @@ void main() {
           reason: "Expecting DimeException thrown error for duplicates.");
     });
     test('add override from new module', () {
-      Dime.installModule(SinglesModuleCopy(), override: true);
+      dimeInstall(SinglesModuleCopy(), override: true);
 
-      var textService = Dime.get<TextService>();
+      var textService = dimeGet<TextService>();
       assert(textService != null);
       assert(textService is MyDescriptionService);
       expect(textService.text(), "Some description for tests. COPY");
 
-      var titleService = Dime.get<MyTitleService>();
+      var titleService = dimeGet<MyTitleService>();
       assert(titleService != null);
       assert(titleService is MyTitleService);
       expect(titleService.text(), "Test title_COPY");
 
       // instance not replaced by new module override
-      var tooltipService = Dime.get<MyTooltipService>();
+      var tooltipService = dimeGet<MyTooltipService>();
       assert(tooltipService != null);
       assert(tooltipService is MyTooltipService);
       expect(tooltipService.text(), "test tooltip");
@@ -79,12 +79,12 @@ void main() {
 
   group('Dime inject - tagged', () {
     setUp(() {
-      Dime.clearAll();
-      Dime.installModule(SinglesModule());
+      dimeReset();
+      dimeInstall(SinglesModule());
     });
 
     test('inject with tag', () {
-      var titleService = Dime.getWithTag<MyTitleService>("Test tag");
+      var titleService = dimeGetWithTag<MyTitleService>("Test tag");
       assert(titleService != null);
       assert(titleService is MyTitleService);
       expect(titleService.text(), "second title");
@@ -92,7 +92,7 @@ void main() {
 
     test('inject with unkown tag', () {
       try {
-        Dime.getWithTag<MyTitleService>("Some random Tag");
+        dimeGetWithTag<MyTitleService>("Some random Tag");
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         expect(e.runtimeType, DimeException);
@@ -104,7 +104,7 @@ void main() {
 
     test('inject with tag on untagged instance', () {
       try {
-        Dime.getWithTag<TextService>("Test");
+        dimeGetWithTag<TextService>("Test");
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         expect(e.runtimeType, DimeException);
@@ -118,13 +118,11 @@ void main() {
   group("Dime inject within module", () {
     // ignore: unnecessary_lambdas
     setUp(() {
-      Dime.clearAll();
+      dimeReset();
     });
     test("Single module dependency", () {
-      Dime.installModule(SameModuleDep());
-      expect(Dime
-          .get<DetailsService>()
-          .runtimeType, DetailsService);
+      dimeInstall(SameModuleDep());
+      expect(dimeGet<DetailsService>().runtimeType, DetailsService);
     });
   });
 

--- a/dime/test/dime_test.dart
+++ b/dime/test/dime_test.dart
@@ -14,14 +14,14 @@ void main() {
     });
 
     test('inject on Interface Test', () {
-      var textService = Dime.inject<TextService>();
+      var textService = Dime.get<TextService>();
       assert(textService != null);
       assert(textService is MyDescriptionService);
       expect(textService.text(), "Some description for tests.");
     });
 
     test('inject on class MyTitleService', () {
-      var textService = Dime.inject<MyTitleService>();
+      var textService = Dime.get<MyTitleService>();
       assert(textService != null);
       assert(textService is MyTitleService);
       expect(textService.text(), "My text title");
@@ -29,7 +29,7 @@ void main() {
 
     test('inject on class MyDescriptionService', () {
       try {
-        Dime.inject<MyDescriptionService>();
+        Dime.get<MyDescriptionService>();
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         assert(e is DimeException);
@@ -39,7 +39,7 @@ void main() {
     });
 
     test('inject on class MyTooltipService', () {
-      var textService = Dime.inject<MyTooltipService>();
+      var textService = Dime.get<MyTooltipService>();
       assert(textService != null);
       assert(textService is MyTooltipService);
       expect(textService.text(), "test tooltip");
@@ -59,18 +59,18 @@ void main() {
     test('add override from new module', () {
       Dime.installModule(SinglesModuleCopy(), override: true);
 
-      var textService = Dime.inject<TextService>();
+      var textService = Dime.get<TextService>();
       assert(textService != null);
       assert(textService is MyDescriptionService);
       expect(textService.text(), "Some description for tests. COPY");
 
-      var titleService = Dime.inject<MyTitleService>();
+      var titleService = Dime.get<MyTitleService>();
       assert(titleService != null);
       assert(titleService is MyTitleService);
       expect(titleService.text(), "Test title_COPY");
 
       // instance not replaced by new module override
-      var tooltipService = Dime.inject<MyTooltipService>();
+      var tooltipService = Dime.get<MyTooltipService>();
       assert(tooltipService != null);
       assert(tooltipService is MyTooltipService);
       expect(tooltipService.text(), "test tooltip");
@@ -84,7 +84,7 @@ void main() {
     });
 
     test('inject with tag', () {
-      var titleService = Dime.injectWithTag<MyTitleService>("Test tag");
+      var titleService = Dime.getWithTag<MyTitleService>("Test tag");
       assert(titleService != null);
       assert(titleService is MyTitleService);
       expect(titleService.text(), "second title");
@@ -92,7 +92,7 @@ void main() {
 
     test('inject with unkown tag', () {
       try {
-        Dime.injectWithTag<MyTitleService>("Some random Tag");
+        Dime.getWithTag<MyTitleService>("Some random Tag");
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         expect(e.runtimeType, DimeException);
@@ -104,7 +104,7 @@ void main() {
 
     test('inject with tag on untagged instance', () {
       try {
-        Dime.injectWithTag<TextService>("Test");
+        Dime.getWithTag<TextService>("Test");
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         expect(e.runtimeType, DimeException);
@@ -123,7 +123,7 @@ void main() {
     test("Single module dependency", () {
       Dime.installModule(SameModuleDep());
       expect(Dime
-          .inject<DetailsService>()
+          .get<DetailsService>()
           .runtimeType, DetailsService);
     });
   });

--- a/dime/test/scope_test.dart
+++ b/dime/test/scope_test.dart
@@ -82,23 +82,47 @@ class DimeScopeTests {
       });
 
       test('test multiple scopes levels injects', () {
-        expect(Dime.inject<CA>().runtimeType, CA);
-        expect(Dime.inject<AA>().runtimeType, AA);
-        expect(Dime.inject<CC>().runtimeType, CC);
+        expect(Dime
+            .get<CA>()
+            .runtimeType, CA);
+        expect(Dime
+            .get<AA>()
+            .runtimeType, AA);
+        expect(Dime
+            .get<CC>()
+            .runtimeType, CC);
         // ignore: unnecessary_lambdas
-        expectException(() => Dime.inject<AB>(), DimeException);
+        expectException(() => Dime.get<AB>(), DimeException);
 
-        expect(scope2.inject<CA>().runtimeType, CA);
-        expect(scope1.inject<CA>().runtimeType, CA);
-        expect(scope1.inject<AA>().runtimeType, AA);
-        expectException(() => scope2.inject<BC>(), DimeException);
-        expect(scope2.inject<AB>().runtimeType, AB);
+        expect(scope2
+            .get<CA>()
+            .runtimeType, CA);
+        expect(scope1
+            .get<CA>()
+            .runtimeType, CA);
+        expect(scope1
+            .get<AA>()
+            .runtimeType, AA);
+        expectException(() => scope2.get<BC>(), DimeException);
+        expect(scope2
+            .get<AB>()
+            .runtimeType, AB);
 
-        expect(scope21.inject<AA>().runtimeType, AA);
-        expect(scope21.inject<CC>().runtimeType, CC);
-        expect(scope22.inject<AC>().runtimeType, AC);
-        expect(scope22.inject<CB>().runtimeType, CB);
-        expect(scope21.inject<BB>().runtimeType, BB);
+        expect(scope21
+            .get<AA>()
+            .runtimeType, AA);
+        expect(scope21
+            .get<CC>()
+            .runtimeType, CC);
+        expect(scope22
+            .get<AC>()
+            .runtimeType, AC);
+        expect(scope22
+            .get<CB>()
+            .runtimeType, CB);
+        expect(scope21
+            .get<BB>()
+            .runtimeType, BB);
       });
     });
   }

--- a/dime/test/scope_test.dart
+++ b/dime/test/scope_test.dart
@@ -56,7 +56,6 @@ void main() {
 /// todo how to resolve duplicate on same level
 ///
 class DimeScopeTests {
-
   static void testScopes() {
     DimeScope scope1;
     DimeScope scope2;
@@ -65,13 +64,13 @@ class DimeScopeTests {
 
     group('Dime inject - scoped', () {
       setUp(() {
-        Dime.clearAll();
-        Dime.installModule(ModuleC());
-        Dime.installModule(ModuleXX(), override: true);
-        scope1 = Dime.openScope("1");
+        dimeReset();
+        dimeInstall(ModuleC());
+        dimeInstall(ModuleXX(), override: true);
+        scope1 = dimeOpenScope("1");
         scope1.installModule(ModuleA());
         scope1.installModule(ModuleB());
-        scope2 = Dime.openScope("2");
+        scope2 = dimeOpenScope("2");
         scope2.installModule(ModuleA());
         scope2.installModule(ModuleC());
         scope21 = scope2.openScope("1");
@@ -82,17 +81,11 @@ class DimeScopeTests {
       });
 
       test('test multiple scopes levels injects', () {
-        expect(Dime
-            .get<CA>()
-            .runtimeType, CA);
-        expect(Dime
-            .get<AA>()
-            .runtimeType, AA);
-        expect(Dime
-            .get<CC>()
-            .runtimeType, CC);
+        expect(dimeGet<CA>().runtimeType, CA);
+        expect(dimeGet<AA>().runtimeType, AA);
+        expect(dimeGet<CC>().runtimeType, CC);
         // ignore: unnecessary_lambdas
-        expectException(() => Dime.get<AB>(), DimeException);
+        expectException(() => dimeGet<AB>(), DimeException);
 
         expect(scope2
             .get<CA>()


### PR DESCRIPTION
0.3.0-rc - Dime static change

- refactored to use static methods as `dime*` not `Dime.` static class
- `Dime.` still available via deprecated API notation
- changed name from `inject` to `get` to better match name to function of the method
- `inject` still available via deprecated API notation
- Code styles updates based on effective-dart lint rules.